### PR TITLE
fix: harden sqlite heartbeat contention

### DIFF
--- a/pkg/client/main.go
+++ b/pkg/client/main.go
@@ -36,6 +36,8 @@ var (
 	numSeekers int
 )
 
+const maxErrorResponseBytes = 4096
+
 // FlagSet returns the flag set understood by the client subcommand.
 // Callers register the flags via Run; this is exposed so the top-level
 // `vkg` binary can render `--help` output for both subcommands.
@@ -256,7 +258,7 @@ func (c *Client) fetchTargets() error {
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("fetch targets: server returned %s", resp.Status)
+		return responseStatusError("fetch targets", resp)
 	}
 
 	var result struct {
@@ -297,7 +299,7 @@ func (c *Client) register() error {
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("register: server returned %s", resp.Status)
+		return responseStatusError("register", resp)
 	}
 
 	var result struct {
@@ -342,10 +344,10 @@ func (c *Client) sendHeartbeat() error {
 		return err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	_, _ = io.Copy(io.Discard, resp.Body)
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("heartbeat: server returned %s", resp.Status)
+		return responseStatusError("heartbeat", resp)
 	}
+	_, _ = io.Copy(io.Discard, resp.Body)
 	return nil
 }
 
@@ -377,12 +379,31 @@ func (c *Client) reportMatch(s seekerStatus) error {
 		return fmt.Errorf("post match: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	_, _ = io.Copy(io.Discard, resp.Body)
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("report match: server returned %s", resp.Status)
+		return responseStatusError("report match", resp)
 	}
+	_, _ = io.Copy(io.Discard, resp.Body)
 	return nil
+}
+
+func responseStatusError(operation string, resp *http.Response) error {
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxErrorResponseBytes+1))
+	if err != nil {
+		return fmt.Errorf("%s: server returned %s: read response body: %w", operation, resp.Status, err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	truncated := ""
+	if len(body) > maxErrorResponseBytes {
+		body = body[:maxErrorResponseBytes]
+		truncated = " (truncated)"
+	}
+	detail := strings.TrimSpace(string(body))
+	if detail == "" {
+		return fmt.Errorf("%s: server returned %s", operation, resp.Status)
+	}
+	return fmt.Errorf("%s: server returned %s: %s%s", operation, resp.Status, detail, truncated)
 }
 
 // Run starts the client. It blocks until interrupted or a fatal error occurs.

--- a/pkg/client/main_test.go
+++ b/pkg/client/main_test.go
@@ -1,0 +1,46 @@
+package client
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestResponseStatusErrorIncludesBody(t *testing.T) {
+	resp := &http.Response{
+		Status: "500 Internal Server Error",
+		Body:   io.NopCloser(strings.NewReader(`{"error":"database is locked (5) (SQLITE_BUSY)"}`)),
+	}
+
+	err := responseStatusError("heartbeat", resp)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "heartbeat: server returned 500 Internal Server Error") {
+		t.Fatalf("expected operation and status in error, got %q", got)
+	}
+	if !strings.Contains(got, "SQLITE_BUSY") {
+		t.Fatalf("expected response body detail in error, got %q", got)
+	}
+}
+
+func TestResponseStatusErrorTruncatesBody(t *testing.T) {
+	resp := &http.Response{
+		Status: "500 Internal Server Error",
+		Body:   io.NopCloser(strings.NewReader(strings.Repeat("x", maxErrorResponseBytes+100))),
+	}
+
+	err := responseStatusError("heartbeat", resp)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "truncated") {
+		t.Fatalf("expected truncation marker in error, got %q", got)
+	}
+	if len(got) > maxErrorResponseBytes+200 {
+		t.Fatalf("error was not bounded: length %d", len(got))
+	}
+}

--- a/pkg/server/routes_clients.go
+++ b/pkg/server/routes_clients.go
@@ -10,7 +10,7 @@ import (
 func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 	var req vkg.RegisterRequest
 	if err := s.readJSON(r, &req); err != nil {
-		s.writeError(w, http.StatusBadRequest, "invalid JSON")
+		s.writeError(w, r, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 
@@ -18,7 +18,7 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 	if clientID == "" {
 		id, err := vkg.NewID()
 		if err != nil {
-			s.writeError(w, http.StatusInternalServerError, "failed to generate client ID")
+			s.writeError(w, r, http.StatusInternalServerError, "failed to generate client ID")
 			return
 		}
 		clientID = id
@@ -34,7 +34,7 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := s.store.UpsertClient(r.Context(), c); err != nil {
-		s.writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeError(w, r, http.StatusInternalServerError, err.Error())
 		return
 	}
 
@@ -46,11 +46,11 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	var hb vkg.Heartbeat
 	if err := s.readJSON(r, &hb); err != nil {
-		s.writeError(w, http.StatusBadRequest, "invalid JSON")
+		s.writeError(w, r, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 	if hb.ClientID == "" {
-		s.writeError(w, http.StatusBadRequest, "client_id is required")
+		s.writeError(w, r, http.StatusBadRequest, "client_id is required")
 		return
 	}
 
@@ -66,7 +66,7 @@ func (s *Server) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := s.store.UpsertClient(r.Context(), c); err != nil {
-		s.writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeError(w, r, http.StatusInternalServerError, err.Error())
 		return
 	}
 
@@ -77,7 +77,7 @@ func (s *Server) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleListClients(w http.ResponseWriter, r *http.Request) {
 	clients, err := s.store.ListClients(r.Context())
 	if err != nil {
-		s.writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeError(w, r, http.StatusInternalServerError, err.Error())
 		return
 	}
 	if clients == nil {
@@ -93,12 +93,12 @@ func (s *Server) handleListClients(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 	clients, err := s.store.ListClients(r.Context())
 	if err != nil {
-		s.writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeError(w, r, http.StatusInternalServerError, err.Error())
 		return
 	}
 	matchCount, err := s.store.MatchCount(r.Context(), "")
 	if err != nil {
-		s.writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeError(w, r, http.StatusInternalServerError, err.Error())
 		return
 	}
 

--- a/pkg/server/routes_matches.go
+++ b/pkg/server/routes_matches.go
@@ -14,7 +14,7 @@ func (s *Server) handleListMatches(w http.ResponseWriter, r *http.Request) {
 
 	matches, err := s.store.ListMatches(r.Context(), targetID, limit)
 	if err != nil {
-		s.writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeError(w, r, http.StatusInternalServerError, err.Error())
 		return
 	}
 	if matches == nil {
@@ -27,11 +27,11 @@ func (s *Server) handleGetMatch(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	m, err := s.store.GetMatch(r.Context(), id)
 	if err != nil {
-		s.writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeError(w, r, http.StatusInternalServerError, err.Error())
 		return
 	}
 	if m == nil {
-		s.writeError(w, http.StatusNotFound, "match not found")
+		s.writeError(w, r, http.StatusNotFound, "match not found")
 		return
 	}
 	s.writeJSON(w, http.StatusOK, map[string]any{"data": m})
@@ -40,7 +40,7 @@ func (s *Server) handleGetMatch(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handlePostMatch(w http.ResponseWriter, r *http.Request) {
 	var m vkg.Match
 	if err := s.readJSON(r, &m); err != nil {
-		s.writeError(w, http.StatusBadRequest, "invalid JSON")
+		s.writeError(w, r, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 
@@ -64,7 +64,7 @@ func (s *Server) handlePostMatch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := s.store.RecordMatch(r.Context(), &m); err != nil {
-		s.writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeError(w, r, http.StatusInternalServerError, err.Error())
 		return
 	}
 

--- a/pkg/server/routes_targets.go
+++ b/pkg/server/routes_targets.go
@@ -64,7 +64,7 @@ func validateTargetEnums(t *vkg.Target) error {
 func (s *Server) handleListTargets(w http.ResponseWriter, r *http.Request) {
 	targets, err := s.store.ListTargets(r.Context())
 	if err != nil {
-		s.writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeError(w, r, http.StatusInternalServerError, err.Error())
 		return
 	}
 	if targets == nil {
@@ -80,33 +80,33 @@ func (s *Server) handleListTargets(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleCreateTarget(w http.ResponseWriter, r *http.Request) {
 	var t vkg.Target
 	if err := s.readJSON(r, &t); err != nil {
-		s.writeError(w, http.StatusBadRequest, "invalid JSON")
+		s.writeError(w, r, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 	// Server owns ID and CreatedAt — clear any client-supplied values.
 	t.ID = ""
 	t.CreatedAt = time.Time{}
 	if t.Pattern == "" {
-		s.writeError(w, http.StatusBadRequest, "pattern is required")
+		s.writeError(w, r, http.StatusBadRequest, "pattern is required")
 		return
 	}
 	if err := validateTargetEnums(&t); err != nil {
-		s.writeError(w, http.StatusBadRequest, err.Error())
+		s.writeError(w, r, http.StatusBadRequest, err.Error())
 		return
 	}
 	if t.Type == "word" {
 		if err := validateWordPattern(t.Pattern); err != nil {
-			s.writeError(w, http.StatusBadRequest, err.Error())
+			s.writeError(w, r, http.StatusBadRequest, err.Error())
 			return
 		}
 	} else {
 		if err := validateRegexPattern(t.Pattern); err != nil {
-			s.writeError(w, http.StatusBadRequest, err.Error())
+			s.writeError(w, r, http.StatusBadRequest, err.Error())
 			return
 		}
 	}
 	if err := s.store.CreateTarget(r.Context(), &t); err != nil {
-		s.writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeError(w, r, http.StatusInternalServerError, err.Error())
 		return
 	}
 	s.hub.Broadcast("target_update", t)
@@ -117,11 +117,11 @@ func (s *Server) handleGetTarget(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	t, err := s.store.GetTarget(r.Context(), id)
 	if err != nil {
-		s.writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeError(w, r, http.StatusInternalServerError, err.Error())
 		return
 	}
 	if t == nil {
-		s.writeError(w, http.StatusNotFound, "target not found")
+		s.writeError(w, r, http.StatusNotFound, "target not found")
 		return
 	}
 	s.writeJSON(w, http.StatusOK, map[string]any{"data": t})
@@ -130,7 +130,7 @@ func (s *Server) handleGetTarget(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleGetActiveTargets(w http.ResponseWriter, r *http.Request) {
 	targets, err := s.store.ListActiveTargets(r.Context())
 	if err != nil {
-		s.writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeError(w, r, http.StatusInternalServerError, err.Error())
 		return
 	}
 	compiled := compilePatterns(targets)
@@ -144,17 +144,17 @@ func (s *Server) handleUpdateTarget(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	existing, err := s.store.GetTarget(r.Context(), id)
 	if err != nil {
-		s.writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeError(w, r, http.StatusInternalServerError, err.Error())
 		return
 	}
 	if existing == nil {
-		s.writeError(w, http.StatusNotFound, "target not found")
+		s.writeError(w, r, http.StatusNotFound, "target not found")
 		return
 	}
 
 	var t vkg.Target
 	if err := s.readJSON(r, &t); err != nil {
-		s.writeError(w, http.StatusBadRequest, "invalid JSON")
+		s.writeError(w, r, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 	// PUT replaces the resource. Server owns ID and CreatedAt; everything
@@ -163,30 +163,30 @@ func (s *Server) handleUpdateTarget(w http.ResponseWriter, r *http.Request) {
 	t.ID = id
 	t.CreatedAt = existing.CreatedAt
 	if t.Type == "" {
-		s.writeError(w, http.StatusBadRequest, "type is required")
+		s.writeError(w, r, http.StatusBadRequest, "type is required")
 		return
 	}
 	if t.Pattern == "" {
-		s.writeError(w, http.StatusBadRequest, "pattern is required")
+		s.writeError(w, r, http.StatusBadRequest, "pattern is required")
 		return
 	}
 	if err := validateTargetEnums(&t); err != nil {
-		s.writeError(w, http.StatusBadRequest, err.Error())
+		s.writeError(w, r, http.StatusBadRequest, err.Error())
 		return
 	}
 	if t.Type == "word" {
 		if err := validateWordPattern(t.Pattern); err != nil {
-			s.writeError(w, http.StatusBadRequest, err.Error())
+			s.writeError(w, r, http.StatusBadRequest, err.Error())
 			return
 		}
 	} else {
 		if err := validateRegexPattern(t.Pattern); err != nil {
-			s.writeError(w, http.StatusBadRequest, err.Error())
+			s.writeError(w, r, http.StatusBadRequest, err.Error())
 			return
 		}
 	}
 	if err := s.store.UpdateTarget(r.Context(), &t); err != nil {
-		s.writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeError(w, r, http.StatusInternalServerError, err.Error())
 		return
 	}
 	s.hub.Broadcast("target_update", t)
@@ -197,11 +197,11 @@ func (s *Server) handleDeleteTarget(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	matchesDeleted, targetDeleted, err := s.store.DeleteTarget(r.Context(), id)
 	if err != nil {
-		s.writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeError(w, r, http.StatusInternalServerError, err.Error())
 		return
 	}
 	if !targetDeleted {
-		s.writeError(w, http.StatusNotFound, "target not found")
+		s.writeError(w, r, http.StatusNotFound, "target not found")
 		return
 	}
 	if matchesDeleted > 0 {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -124,8 +124,16 @@ func (s *Server) readJSON(r *http.Request, v any) error {
 	return json.NewDecoder(r.Body).Decode(v)
 }
 
-// writeError writes a JSON error response.
-func (s *Server) writeError(w http.ResponseWriter, status int, msg string) {
+// writeError writes a JSON error response and logs server-side failures.
+func (s *Server) writeError(w http.ResponseWriter, r *http.Request, status int, msg string) {
+	if status >= http.StatusInternalServerError {
+		s.logger.Error("HTTP request failed",
+			"method", r.Method,
+			"path", r.URL.Path,
+			"status", status,
+			"error", msg,
+		)
+	}
 	s.writeJSON(w, status, map[string]string{"error": msg})
 }
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,0 +1,55 @@
+package server
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestWriteErrorLogsServerFailures(t *testing.T) {
+	var logs bytes.Buffer
+	s := &Server{
+		logger: slog.New(slog.NewJSONHandler(&logs, nil)),
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/clients/heartbeat", nil)
+	rec := httptest.NewRecorder()
+
+	s.writeError(rec, req, http.StatusInternalServerError, "database is locked")
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", rec.Code)
+	}
+	got := logs.String()
+	for _, want := range []string{
+		`"msg":"HTTP request failed"`,
+		`"method":"POST"`,
+		`"path":"/api/clients/heartbeat"`,
+		`"status":500`,
+		`"error":"database is locked"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected log to contain %s, got %s", want, got)
+		}
+	}
+}
+
+func TestWriteErrorDoesNotLogClientFailures(t *testing.T) {
+	var logs bytes.Buffer
+	s := &Server{
+		logger: slog.New(slog.NewJSONHandler(&logs, nil)),
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/clients/heartbeat", nil)
+	rec := httptest.NewRecorder()
+
+	s.writeError(rec, req, http.StatusBadRequest, "invalid JSON")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", rec.Code)
+	}
+	if got := logs.String(); got != "" {
+		t.Fatalf("expected no log for client failure, got %s", got)
+	}
+}

--- a/pkg/server/sse.go
+++ b/pkg/server/sse.go
@@ -81,7 +81,7 @@ func (h *Hub) Broadcast(eventType string, data any) {
 func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
-		s.writeError(w, http.StatusInternalServerError, "streaming not supported")
+		s.writeError(w, r, http.StatusInternalServerError, "streaming not supported")
 		return
 	}
 

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -64,18 +64,18 @@ type Store struct {
 
 // New opens (or creates) a SQLite database and runs migrations.
 //
-// In-memory paths (":memory:" or "file::memory:...") are pinned to a
-// single connection because each new database/sql connection to an
-// in-memory database opens its own empty database, which would lose
-// the schema and any data written through other connections.
+// SQLite is pinned to a single database/sql connection so writes are
+// serialized inside the process and connection-local pragmas such as
+// busy_timeout apply to every store operation. This is also required
+// for in-memory databases, where each connection would otherwise see
+// a separate empty database.
 func New(dbPath string) (*Store, error) {
 	db, err := sql.Open("sqlite", dbPath)
 	if err != nil {
 		return nil, fmt.Errorf("open db: %w", err)
 	}
-	if isInMemoryDSN(dbPath) {
-		db.SetMaxOpenConns(1)
-	}
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
 	// SQLite performance pragmas
 	for _, pragma := range []string{
 		"PRAGMA journal_mode=WAL",
@@ -92,10 +92,6 @@ func New(dbPath string) (*Store, error) {
 		return nil, fmt.Errorf("migrate: %w", err)
 	}
 	return &Store{db: db}, nil
-}
-
-func isInMemoryDSN(dsn string) bool {
-	return dsn == ":memory:" || strings.Contains(dsn, ":memory:")
 }
 
 // Close closes the underlying database handle.

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -2,6 +2,9 @@ package store
 
 import (
 	"context"
+	"fmt"
+	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -160,6 +163,70 @@ func TestClientUpsertAndList(t *testing.T) {
 	}
 	if clients[0].KeyRate != 1234.5 {
 		t.Errorf("expected key rate 1234.5, got %f", clients[0].KeyRate)
+	}
+}
+
+func TestFileStoreUsesSingleConnection(t *testing.T) {
+	s, err := New(filepath.Join(t.TempDir(), "vkg.db"))
+	if err != nil {
+		t.Fatalf("New(file): %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	if got := s.db.Stats().MaxOpenConnections; got != 1 {
+		t.Fatalf("expected file-backed store to use 1 open connection, got %d", got)
+	}
+}
+
+func TestConcurrentClientWritesDoNotReturnBusy(t *testing.T) {
+	s, err := New(filepath.Join(t.TempDir(), "vkg.db"))
+	if err != nil {
+		t.Fatalf("New(file): %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 32)
+	var wg sync.WaitGroup
+	for worker := 0; worker < 8; worker++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			for i := 0; i < 40; i++ {
+				client := &vkg.ClientInfo{
+					ID:       fmt.Sprintf("client-%02d", worker),
+					Hostname: fmt.Sprintf("host-%02d", worker),
+					Version:  "test",
+					Seekers:  4,
+					KeyRate:  float64(i),
+					KeyCount: int64(i),
+					LastSeen: time.Now().UTC(),
+					Status:   "active",
+				}
+				if err := s.UpsertClient(ctx, client); err != nil {
+					errCh <- fmt.Errorf("upsert client %d: %w", worker, err)
+					return
+				}
+				if i%10 == 0 {
+					if err := s.MarkOfflineClients(ctx, 90*time.Second); err != nil {
+						errCh <- fmt.Errorf("mark offline: %w", err)
+						return
+					}
+					if err := s.DeleteOfflineClients(ctx, 5*time.Minute); err != nil {
+						errCh <- fmt.Errorf("delete offline: %w", err)
+						return
+					}
+				}
+			}
+		}(worker)
+	}
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		t.Error(err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- serialize SQLite access through a single `database/sql` connection so write-heavy paths share the configured pragmas and do not fight each other through the pool
- include bounded response bodies in client non-2xx errors for register, target fetch, heartbeat, and match reporting
- log server 5xx responses with method, path, status, and error context
- add coverage for file-backed store connection policy, concurrent client writes, bounded client error detail, and 5xx logging

## Root Cause

The server enabled WAL and `busy_timeout`, but file-backed SQLite could still use multiple pooled connections. SQLite pragmas are connection-local, so later pooled connections could miss the timeout and concurrent writes from heartbeats, match reports, target changes, and the client reaper could surface `SQLITE_BUSY` as heartbeat 500s.

Closes #5.

## Validation

- `just test`
- `just ci`
